### PR TITLE
Add createMany and related methods

### DIFF
--- a/src/ArrayFactory.php
+++ b/src/ArrayFactory.php
@@ -107,6 +107,15 @@ class ArrayFactory
     }
 
     /**
+     * @param array<string, mixed> ...$state
+     * @return array<int, array<string, mixed>>
+     */
+    public function createMany(array ...$state): array
+    {
+        return $this->forEachSequence(...$state)->create();
+    }
+
+    /**
      * @param array<string, mixed> $state
      * @return TDtoClass
      */
@@ -125,6 +134,15 @@ class ArrayFactory
     }
 
     /**
+     * @param array<string, mixed> ...$state
+     * @return array<int, TDtoClass>
+     */
+    public function manyAsDtos(array ...$state): array
+    {
+        return $this->forEachSequence(...$state)->asDtos();
+    }
+
+    /**
      * @param array<string, mixed> $state
      * @return TCollectionClass<int, array<string, mixed>>
      */
@@ -134,12 +152,30 @@ class ArrayFactory
     }
 
     /**
+     * @param array<string, mixed> ...$state
+     * @return TCollectionClass<int, array<string, mixed>>
+     */
+    public function manyAsCollection(array ...$state): Collection
+    {
+        return $this->forEachSequence(...$state)->asCollection();
+    }
+
+    /**
      * @param array<string, mixed> $state
      * @return TCollectionClass<int, TDtoClass>
      */
     public function asDtoCollection(array $state = []): Collection
     {
         return new ($this->collection)($this->asDtos($state));
+    }
+
+    /**
+     * @param array<string, mixed> $state
+     * @return TCollectionClass<int, TDtoClass>
+     */
+    public function manyAsDtoCollection(array ...$state): Collection
+    {
+        return $this->forEachSequence(...$state)->asDtoCollection();
     }
 
     /**

--- a/tests/ArrayFactoryTest.php
+++ b/tests/ArrayFactoryTest.php
@@ -194,6 +194,15 @@ it('allows to create all items of the sequence', function (): void {
     ]);
 });
 
+it('allows to create many items', function (): void {
+    $factory = new ArrayFactory(['foo' => 'bar']);
+
+    expect($factory->createMany(['foo' => 'qux'], ['foo' => 'bar']))->toBe([
+        ['foo' => 'qux'],
+        ['foo' => 'bar'],
+    ]);
+});
+
 it('allows to create with cross joined sequence', function (): void {
     $factory = new ArrayFactory();
 
@@ -273,6 +282,26 @@ it('allows get the result as array of dtos with override', function (): void {
         ->email->toBe('email@email.com');
 });
 
+it('allows get many results as array of dtos', function (): void {
+    $factory = new ArrayFactory(
+        definition: ['id' => 1, 'email' => 'email@email.com'],
+        dto: CustomDTO::class,
+    );
+
+    $dtos = $factory->manyAsDtos(['id' => 2], ['id' => 3]);
+    expect($dtos)
+        ->toBeArray()
+        ->toHaveCount(2);
+
+    expect($dtos[0])->toBeInstanceOf(CustomDTO::class)
+        ->id->toBe(2)
+        ->email->toBe('email@email.com');
+
+    expect($dtos[1])->toBeInstanceOf(CustomDTO::class)
+        ->id->toBe(3)
+        ->email->toBe('email@email.com');
+});
+
 it('allows to create multiple items as a collection', function (): void {
     $factory = new ArrayFactory(['foo' => 'bar']);
 
@@ -292,6 +321,17 @@ it('allows to create multiple items as a collection with override', function ():
         ->all()->toBe([
             ['foo' => 'qux'],
             ['foo' => 'qux'],
+        ]);
+});
+
+it('allows to create many items as a collection', function (): void {
+    $factory = new ArrayFactory(['foo' => 'bar']);
+
+    expect($factory->manyAsCollection(['foo' => 'qux'], ['foo' => 'baz']))
+        ->toBeInstanceOf(Collection::class)
+        ->all()->toBe([
+            ['foo' => 'qux'],
+            ['foo' => 'baz'],
         ]);
 });
 
@@ -344,5 +384,26 @@ it('allows get the result as collection of dtos with override', function (): voi
 
     expect($dtos->first())->toBeInstanceOf(CustomDTO::class)
         ->id->toBe(2)
+        ->email->toBe('email@email.com');
+});
+
+it('allows get many results as collection of dtos', function (): void {
+    $factory = new ArrayFactory(
+        definition: ['id' => 1, 'email' => 'email@email.com'],
+        dto: CustomDTO::class,
+        collection: CustomCollection::class,
+    );
+
+    $dtos = $factory->manyAsDtoCollection(['id' => 2], ['id' => 3]);
+    expect($dtos)
+        ->toBeInstanceOf(CustomCollection::class)
+        ->toHaveCount(2);
+
+    expect($dtos->first())->toBeInstanceOf(CustomDTO::class)
+        ->id->toBe(2)
+        ->email->toBe('email@email.com');
+
+    expect($dtos->last())->toBeInstanceOf(CustomDTO::class)
+        ->id->toBe(3)
         ->email->toBe('email@email.com');
 });

--- a/types/ArrayFactory.php
+++ b/types/ArrayFactory.php
@@ -21,6 +21,10 @@ assertType(
     $factory->create()
 );
 assertType(
+    'array<int, array<string, mixed>>',
+    $factory->createMany()
+);
+assertType(
     'Spatie\\DataTransferObject\\DataTransferObject',
     $factory->asDto()
 );
@@ -29,12 +33,24 @@ assertType(
     $factory->asDtos()
 );
 assertType(
+    'array<int, Spatie\\DataTransferObject\\DataTransferObject>',
+    $factory->manyAsDtos()
+);
+assertType(
     'Illuminate\\Support\\Collection<int, array<string, mixed>>',
     $factory->asCollection()
 );
 assertType(
+    'Illuminate\\Support\\Collection<int, array<string, mixed>>',
+    $factory->manyAsCollection()
+);
+assertType(
     'Illuminate\\Support\\Collection<int, Spatie\\DataTransferObject\\DataTransferObject>',
     $factory->asDtoCollection()
+);
+assertType(
+    'Illuminate\\Support\\Collection<int, Spatie\\DataTransferObject\\DataTransferObject>',
+    $factory->manyAsDtoCollection()
 );
 
 $newFactory = ArrayFactory::new(['foo' => 'bar']);
@@ -48,12 +64,24 @@ assertType(
     $newFactory->asDtos()
 );
 assertType(
+    'array<int, Spatie\\DataTransferObject\\DataTransferObject>',
+    $newFactory->manyAsDtos()
+);
+assertType(
     'Illuminate\\Support\\Collection<int, array<string, mixed>>',
     $newFactory->asCollection()
 );
 assertType(
+    'Illuminate\\Support\\Collection<int, array<string, mixed>>',
+    $newFactory->manyAsCollection()
+);
+assertType(
     'Illuminate\\Support\\Collection<int, Spatie\\DataTransferObject\\DataTransferObject>',
     $newFactory->asDtoCollection()
+);
+assertType(
+    'Illuminate\\Support\\Collection<int, Spatie\\DataTransferObject\\DataTransferObject>',
+    $newFactory->manyAsDtoCollection()
 );
 
 $timesFactory = ArrayFactory::times(2);
@@ -77,6 +105,10 @@ assertType(
     $factoryWithCustoms->create()
 );
 assertType(
+    'array<int, array<string, mixed>>',
+    $factoryWithCustoms->createMany()
+);
+assertType(
     'Soyhuce\\ArrayFactory\\Tests\\Fixtures\\CustomDTO',
     $factoryWithCustoms->asDto()
 );
@@ -84,13 +116,25 @@ assertType(
     'array<int, Soyhuce\\ArrayFactory\\Tests\\Fixtures\\CustomDTO>',
     $factoryWithCustoms->asDtos()
 );
+assertType(
+    'array<int, Soyhuce\\ArrayFactory\\Tests\\Fixtures\\CustomDTO>',
+    $factoryWithCustoms->manyAsDtos()
+);
 // assertType(
 //    'Soyhuce\\ArrayFactory\\Tests\\Fixtures\\CustomCollection<int, array<string, mixed>>',
 //    $factoryWithCustoms->asCollection()
 // );
 // assertType(
+//    'Soyhuce\\ArrayFactory\\Tests\\Fixtures\\CustomCollection<int, array<string, mixed>>',
+//    $factoryWithCustoms->manyAsCollection()
+// );
+// assertType(
 //    'Soyhuce\\ArrayFactory\\Tests\\Fixtures\\CustomCollection<int, Soyhuce\\ArrayFactory\\Tests\\Fixtures\\CustomDTO>',
 //    $factoryWithCustoms->asDtoCollection()
+// );
+// assertType(
+//    'Soyhuce\\ArrayFactory\\Tests\\Fixtures\\CustomCollection<int, Soyhuce\\ArrayFactory\\Tests\\Fixtures\\CustomDTO>',
+//    $factoryWithCustoms->manyAsDtoCollection()
 // );
 
 $customFactory = new CustomArrayFactory();
@@ -112,6 +156,10 @@ assertType(
     $customFactory->create()
 );
 assertType(
+    'array<int, array<string, mixed>>',
+    $customFactory->createMany()
+);
+assertType(
     'Soyhuce\\ArrayFactory\\Tests\\Fixtures\\CustomDTO',
     $customFactory->asDto()
 );
@@ -119,13 +167,25 @@ assertType(
     'array<int, Soyhuce\\ArrayFactory\\Tests\\Fixtures\\CustomDTO>',
     $customFactory->asDtos()
 );
+assertType(
+    'array<int, Soyhuce\\ArrayFactory\\Tests\\Fixtures\\CustomDTO>',
+    $customFactory->manyAsDtos()
+);
 // assertType(
 //    'Soyhuce\\ArrayFactory\\Tests\\Fixtures\\CustomCollection<int, array<string, mixed>>',
 //    $customFactory->asCollection()
 // );
 // assertType(
+//    'Soyhuce\\ArrayFactory\\Tests\\Fixtures\\CustomCollection<int, array<string, mixed>>',
+//    $customFactory->manyAsCollection()
+// );
+// assertType(
 //    'Soyhuce\\ArrayFactory\\Tests\\Fixtures\\CustomCollection<int, Soyhuce\\ArrayFactory\\Tests\\Fixtures\\CustomDTO>',
 //    $customFactory->asDtoCollection()
+// );
+// assertType(
+//    'Soyhuce\\ArrayFactory\\Tests\\Fixtures\\CustomCollection<int, Soyhuce\\ArrayFactory\\Tests\\Fixtures\\CustomDTO>',
+//    $customFactory->manyAsDtoCollection()
 // );
 
 assertType(


### PR DESCRIPTION
Allows to simplifications:
before
```php
UserDefinedSlotFactory::new()
    ->forEachSequence(
        ['project_activity_id' => $projectActivity->id],
        ['project_activity_id' => null],
    )
    ->asDtoCollection()
```
After
```php
UserDefinedSlotFactory::new()
    ->manyAsDtoCollection(
        ['project_activity_id' => $projectActivity->id],
        ['project_activity_id' => null],
    )
```